### PR TITLE
new styles for details and summary

### DIFF
--- a/posts/changelog.html
+++ b/posts/changelog.html
@@ -142,7 +142,7 @@
 </head>
 
 <body>
-  <article>
+  <main>
     <header>
       <nav>
         <button class="homebtn" type="button" onclick="window.location.href='../index.html';">home</button>
@@ -350,6 +350,6 @@
       <p>My post describing how to take advantage of Windows Virtual Desktops when shifting between tasks.</p>
     </details>
 
-  </article>
+  </main>
 </body>
 </html>

--- a/posts/loading-images-only-when-they-are-needed.html
+++ b/posts/loading-images-only-when-they-are-needed.html
@@ -169,8 +169,8 @@
       <h2>The solution</h2>
       <p>I've already used a non-JS method for hiding content until it's requested by the user on the <a href="/posts/changelog.html">Changelog</a> page i.e. the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary">&lt;details&gt; and &lt;summary&gt; HTML elements</a>. So I decided to use these elements with the summary text of <i>Show me how</i>, which when clicked would display the contents of the &lt;details&gt; element i.e. the animated GIF. You can see this in action for a static image by clicking on the text below to display [<span class="fig-ref">fig. 1</span>].</p>
 
-      <details style="background-color:white; margin-top:-30px; margin-left:-10px; color:#3d74bd">
-      <summary><b>Click here to see Figure 1</b></summary>
+      <details>
+      <summary>Click here to see Figure 1</summary>
       <figure>
         <img src="../images/subscribecompare.webp" width="800" height="1059" loading="lazy" alt=" ">
         <figcaption>Figure 1. The original Subscribe page (left) alongside the final Subscribe page (right).</figcaption>

--- a/posts/subscribe.html
+++ b/posts/subscribe.html
@@ -189,7 +189,7 @@
         <li>Select OnlyRSS from the feed results.</li>
         <li>Select 'follow' and add to a folder.</li>
       </ol>
-      <details style="background-color:white; margin-top:-30px; margin-left:-10px;"><summary>Show me how</summary>
+      <details><summary>Show me how</summary>
         <img src="../images/feedlysubscribe.gif" width="800" height="777" alt="Animated GIF showing how to subscribe to a feed in Feedly" loading="lazy">
       </details>
     </section>
@@ -206,10 +206,11 @@
         <li>Paste the copied URL into the search field.</li>
         <li>Select OnlyRSS from the feed results.</li>
       </ol>
-      <details style="background-color:white; margin-top:-30px; margin-left:-10px;"><summary>Show me how</summary>
+      <details><summary>Show me how</summary>
         <img src="../images/inoreadersubscribe.gif" width="800" height="777" alt="Animated GIF showing how to subscribe to a feed in Inoreader" loading="lazy">
       </details>
     </section>
+    <hr>
 
   </article>
 </body>

--- a/styles/article-main.css
+++ b/styles/article-main.css
@@ -19,6 +19,7 @@ html {
   }
 
   article,
+  main,
   aside {
     padding-left: 30px;
     padding-right: 30px;
@@ -41,6 +42,7 @@ html {
   }
 
   article,
+  main,
   aside {
     padding-left: 60px;
     padding-right: 60px;
@@ -67,6 +69,7 @@ html {
   }
 
   article,
+  main,
   aside {
     padding-left: 90px;
     padding-right: 90px;
@@ -114,6 +117,7 @@ img {
 
 /* the article and aside containers are the same, with the exception of the top padding */
 article,
+main,
 aside {
   background-color: #ffffff;
   border-radius: 5px;
@@ -124,7 +128,8 @@ aside {
   margin-bottom: 20px;
 }
 
-article {
+article,
+main {
   padding-top: 40px;
 }
 
@@ -319,27 +324,40 @@ abbr {
   color: black;
 }
 
-/* TODO fork the summay style for Article pages */
-/* Details and Summary (mostly used on Changelog page */
-summary {
+/* style="background-color:white; margin-top:-30px; margin-left:-10px;" */
+
+/* Details and Summary for ARTICLE pages i.e. uses <article> */
+article summary {
+  cursor: pointer;
+  font-weight: 600;
+  color:var(--accent);
+}
+
+/* Details and Summary for the CHANGELOG page i.e. uses <main> */
+main summary {
   font-weight: 400;
   display: flex;
+  cursor: pointer;
   /* set summary elements to flex to enable the tags to be right-aligned, see below */
 }
 
-details {
+main details {
   background-color: #e2f4ff;
   border-radius: 5px;
   line-height: 2em;
   padding: 0.7em 0.7em 0em;
   font-size: 0.8em;
-  cursor: pointer;
   margin-bottom: 1em;
 }
 
-details[open] summary {
+main details[open] summary {
   border-bottom: 1px solid #aaa;
   margin-bottom: 1em;
+}
+
+/* remove the arrow on iOS */
+main details summary::-webkit-details-marker {
+  display:none;
 }
 
 /* Tags for Changelog page */


### PR DESCRIPTION
Defined the details/summary styles differently, one style for articles, and another for Changelog (which uses <main> rather than <article>. Also removed the arrow alongside the details./summary on web kit.