### PR TITLE
new details/summary open/close UI

### DIFF
--- a/apps/circuits.html
+++ b/apps/circuits.html
@@ -21,7 +21,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <style>

--- a/demo/bar-charts.html
+++ b/demo/bar-charts.html
@@ -28,7 +28,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="stylesheet" type="text/css" href="/styles/bar-charts.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     

--- a/demo/learning-log-2023.html
+++ b/demo/learning-log-2023.html
@@ -28,7 +28,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     
     <!--load self-hosted fonts-->

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--Roboto Condensed for nav bar, Open Sans regular and bold for cards-->

--- a/pages/about.html
+++ b/pages/about.html
@@ -30,7 +30,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/pages/changelog.html
+++ b/pages/changelog.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/pages/subscribe.html
+++ b/pages/subscribe.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/posts/10-benefits-of-rss-for-product-managers.html
+++ b/posts/10-benefits-of-rss-for-product-managers.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     
     <!--load self-hosted fonts-->

--- a/posts/adding-screenshots-to-your-pwa-install.html
+++ b/posts/adding-screenshots-to-your-pwa-install.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/posts/airbus-vs-boeing-charts.html
+++ b/posts/airbus-vs-boeing-charts.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="stylesheet" type="text/css" href="/styles/airbus-vs-boeing-charts.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     

--- a/posts/anatomy-of-a-lockdown-day.html
+++ b/posts/anatomy-of-a-lockdown-day.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     
     <!--load self-hosted fonts-->

--- a/posts/auto-numbering-of-figures-with-CSS-counters.html
+++ b/posts/auto-numbering-of-figures-with-CSS-counters.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/posts/chart-picker.html
+++ b/posts/chart-picker.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     
     <!--load self-hosted fonts-->

--- a/posts/css-balance.html
+++ b/posts/css-balance.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     
     <!--load self-hosted fonts-->

--- a/posts/drawing-with-excalidraw.html
+++ b/posts/drawing-with-excalidraw.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     
     <!--load self-hosted fonts-->

--- a/posts/learning-log-2022.html
+++ b/posts/learning-log-2022.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     
     <!--load self-hosted fonts-->

--- a/posts/linking-tables-to-bar-charts.html
+++ b/posts/linking-tables-to-bar-charts.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     
     <!--load self-hosted fonts-->

--- a/posts/loading-images-only-when-they-are-needed.html
+++ b/posts/loading-images-only-when-they-are-needed.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/posts/my-first-javascript-app.html
+++ b/posts/my-first-javascript-app.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/posts/my-rowing-tips-after-15-million-meters.html
+++ b/posts/my-rowing-tips-after-15-million-meters.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/posts/rss-part-1.html
+++ b/posts/rss-part-1.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/posts/table-with-progress-indicator.html
+++ b/posts/table-with-progress-indicator.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     
     <!--load self-hosted fonts-->

--- a/posts/the-air-india-order.html
+++ b/posts/the-air-india-order.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="stylesheet" type="text/css" href="/styles/the-air-india-order.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     

--- a/posts/top-25-pax-airlines.html
+++ b/posts/top-25-pax-airlines.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="stylesheet" type="text/css" href="/styles/top-25-pax-airlines-1.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     

--- a/posts/top-9-aircraft-families.html
+++ b/posts/top-9-aircraft-families.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="stylesheet" type="text/css" href="/styles/top-9-aircraft-families.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
     

--- a/posts/using-virtual-desktops-in-windows-10.html
+++ b/posts/using-virtual-desktops-in-windows-10.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/posts/why-every-product-manager-should-build-a-website.html
+++ b/posts/why-every-product-manager-should-build-a-website.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/posts/why-i-prefer-the-kindle.html
+++ b/posts/why-i-prefer-the-kindle.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--extra stylesheet for the Kindle-->

--- a/posts/working-from-home-hardware.html
+++ b/posts/working-from-home-hardware.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
 
     <!--load self-hosted fonts-->

--- a/posts/zoom-and-enhance.html
+++ b/posts/zoom-and-enhance.html
@@ -29,7 +29,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <!--stylesheet and RSS-->
-    <link rel="stylesheet" type="text/css" href="/styles/main77.css">
+    <link rel="stylesheet" type="text/css" href="/styles/main78.css">
     <link rel="alternate" type="application/rss+xml" title="RSS Feed for OnlyRSS.org" href="/feed.xml">
  
     <!--load self-hosted fonts-->

--- a/styles/main78.css
+++ b/styles/main78.css
@@ -811,12 +811,14 @@ aside h2:hover {
 }
 
 /* ====== Details and Summary for changelog page====== */
+
+  /* set summary elements to flex to enable the tags to be right-aligned */
 .changelog summary {
   font-weight: 400;
   display: flex;
   align-items: center; /* centre them vertically */
   cursor: pointer;
-  /* set summary elements to flex to enable the tags to be right-aligned, see below */
+  -webkit-tap-highlight-color: rgba(255, 255, 255, 0); /* remove the highlight when tapped */
 }
 
 /* remove the focus box, and make bold the focus state (for users who tab through the page */
@@ -834,21 +836,26 @@ aside h2:hover {
   padding: 0.35rem 0.7rem 0.35rem;
 }
 
- .changelog[open] summary {
-  border-bottom: 1px solid #aaa;
-  margin-bottom: 1rem;
+
+/* append ">" to the start of summary text */
+.changelog summary::before {
+  content: url("data:image/svg+xml,%3Csvg viewBox='0 0 6 10' height='10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 1 1 L 5 5 l -4 4' stroke='black'/%3E%3C/svg%3E");
+  margin-right: 0.5rem;
+  font-size: 1.3rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  text-align: center;
+  border-radius: 7px;
+  background-color: white;
+  display: inline-block;
+  margin-left: -5px;
+  transition: transform 0.3s ease-out;
 }
 
-/* append "+" to the start of summary text */
-.changelog summary::before {
-  content: "+";
-  padding-right: 0.5rem;
-  font-size: 1.3rem;
-  width: 1rem;
-}
-/* append "-" to the start of summary text when changelog is open */
- .changelog[open] summary::before {
-  content: "–";
+/* rotate when opened/closed */
+.changelog[open] summary::before {
+  transform: rotate(90deg);
+  -webkit-transform: rotate(90deg); /* added this line for Safari - yet it still doesn't work on Safari :-( */
 }
 
 /* remove the arrow on iOS */


### PR DESCRIPTION
Removed the +- as the UI for opening and closing the Changelog Details/Summary elements. Used an SVR chevron and a rotate animation. Rotate does NOT seem to work on Safari, I'm not sure why.